### PR TITLE
Add stub routes for reports and settings

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -3,4 +3,6 @@ from . import views
 
 urlpatterns = [
     path('', views.dashboard, name='dashboard'),
+    path('relatorios/', views.relatorios, name='relatorios'),
+    path('configuracoes/', views.configuracoes, name='configuracoes'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -250,3 +250,24 @@ def produtos_delete(request, pk):
         messages.success(request, f"Produto “{name}” excluído.")
         return redirect("estoque-produtos")
     return render(request, "confirm_delete.html", {"title": "Excluir produto", "object": obj})
+
+
+# ----------------------
+# RELATÓRIOS & CONFIGURAÇÕES (STUBS)
+# ----------------------
+
+
+def relatorios(request):
+    return render(
+        request,
+        "stub.html",
+        {"title": "Relatórios", "text": "Página de relatórios em construção."},
+    )
+
+
+def configuracoes(request):
+    return render(
+        request,
+        "stub.html",
+        {"title": "Configurações", "text": "Página de configurações em construção."},
+    )

--- a/mfgsite/urls.py
+++ b/mfgsite/urls.py
@@ -21,4 +21,8 @@ urlpatterns = [
     path("produtos/novo/", v.produtos_new, name="produtos-new"),
     path("produtos/<int:pk>/editar/", v.produtos_edit, name="produtos-edit"),
     path("produtos/<int:pk>/excluir/", v.produtos_delete, name="produtos-delete"),
+
+    # Relatórios e Configurações
+    path("relatorios/", v.relatorios, name="relatorios"),
+    path("configuracoes/", v.configuracoes, name="configuracoes"),
 ]


### PR DESCRIPTION
## Summary
- Add placeholder views for reports and settings
- Wire new routes so navigation links no longer raise NoReverseMatch

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a370bdabcc8320bd8e4ca753319327