### PR TITLE
Fix estoque templates path

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -144,7 +144,11 @@ def estoque_componentes_list(request):
     if q:
         qs = qs.filter(Q(code__icontains=q) | Q(name__icontains=q))
     components = list(qs.order_by("code", "name"))
-    return render(request, "componentes_list.html", {"components": components, "q": q})
+    return render(
+        request,
+        "estoque/componentes_list.html",
+        {"components": components, "q": q},
+    )
 
 
 def componentes_new(request):
@@ -214,7 +218,11 @@ def estoque_produtos_list(request):
                 "total_time_min": total_time_min,
             }
         )
-    return render(request, "produtos_list.html", {"products": rows, "q": q})
+    return render(
+        request,
+        "estoque/produtos_list.html",
+        {"products": rows, "q": q},
+    )
 
 
 def produtos_new(request):


### PR DESCRIPTION
## Summary
- Render inventory views using the correct `estoque/` template paths

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a37adfbc7c832088c9794157eb9686