### PR TITLE
Add material and production time fields to components

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -6,9 +6,10 @@ class ComponentForm(forms.ModelForm):
     # Entrada sempre em minutos
     class Meta:
         model = Component
-        fields = ['code', 'name', 'description', 'unit_cost', 'print_time_min', 'qty_on_hand']
+        fields = ['code', 'name', 'description', 'material', 'unit_cost', 'production_time', 'print_time_min', 'qty_on_hand']
         widgets = {
-            'description': forms.Textarea(attrs={'rows':3})
+            'description': forms.Textarea(attrs={'rows':3}),
+            'production_time': forms.TextInput(attrs={'placeholder': 'hh:mm:ss'}),
         }
 
 class ProductForm(forms.ModelForm):

--- a/core/migrations/0002_component_material_production_time.py
+++ b/core/migrations/0002_component_material_production_time.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+import datetime
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='component',
+            name='material',
+            field=models.CharField(verbose_name='Material', max_length=60, blank=True),
+        ),
+        migrations.AddField(
+            model_name='component',
+            name='production_time',
+            field=models.DurationField(verbose_name='Tempo de produção', default=datetime.timedelta()),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 from django.core.validators import MinValueValidator
+from datetime import timedelta
 
 # ======== Helpers ========
 def minutes_to_hhmm(total_minutes: int) -> str:
@@ -14,7 +15,9 @@ class Component(models.Model):
     code = models.CharField("Código", max_length=32, unique=True)
     name = models.CharField("Nome", max_length=120)
     description = models.TextField("Descrição", blank=True)
+    material = models.CharField("Material", max_length=60, blank=True)
     unit_cost = models.DecimalField("Custo unitário (R$)", max_digits=10, decimal_places=2, default=0)
+    production_time = models.DurationField("Tempo de produção", default=timedelta())
     # tempo de impressão por unidade (em MINUTOS) — cadastra em minutos
     print_time_min = models.PositiveIntegerField("Tempo de impressão (min/un)", default=0)
 
@@ -27,7 +30,8 @@ class Component(models.Model):
         ordering = ["code"]
 
     def __str__(self):
-        return f"{self.code} - {self.name}"
+        mat = f" ({self.material})" if self.material else ""
+        return f"{self.code} - {self.name}{mat}"
 
     @property
     def print_time_hhmm(self):

--- a/templates/componentes_form.html
+++ b/templates/componentes_form.html
@@ -4,12 +4,14 @@
 <div class="page-header"><div class="page-title">{% if form.instance.pk %}Editar componente{% else %}Criar componente{% endif %}</div></div>
 <form method="post" class="block form">
   {% csrf_token %}
-  <div class="field"><label for="{{ form.code.id_for_label }}">Código</label>{{ form.code }}</div>
-  <div class="field"><label for="{{ form.name.id_for_label }}">Nome</label>{{ form.name }}</div>
-  <div class="field"><label for="{{ form.description.id_for_label }}">Descrição</label>{{ form.description }}</div>
-  <div class="field"><label for="{{ form.unit_cost.id_for_label }}">Custo unitário (R$)</label>{{ form.unit_cost }}</div>
-  <div class="field"><label for="{{ form.print_time_mins.id_for_label }}">Tempo de impressão (min/un)</label>{{ form.print_time_mins }}</div>
-  <div class="field"><label for="{{ form.qty_on_hand.id_for_label }}">Qtd em estoque</label>{{ form.qty_on_hand }}</div>
+  <div class="field"><label for="{{ form.code.id_for_label }}">Código</label>{{ form.code }}{% if form.code.errors %}<div class="error">{{ form.code.errors|striptags }}</div>{% endif %}</div>
+  <div class="field"><label for="{{ form.name.id_for_label }}">Nome</label>{{ form.name }}{% if form.name.errors %}<div class="error">{{ form.name.errors|striptags }}</div>{% endif %}</div>
+  <div class="field"><label for="{{ form.description.id_for_label }}">Descrição</label>{{ form.description }}{% if form.description.errors %}<div class="error">{{ form.description.errors|striptags }}</div>{% endif %}</div>
+  <div class="field"><label for="{{ form.material.id_for_label }}">Material</label>{{ form.material }}{% if form.material.errors %}<div class="error">{{ form.material.errors|striptags }}</div>{% endif %}</div>
+  <div class="field"><label for="{{ form.unit_cost.id_for_label }}">Custo unitário (R$)</label>{{ form.unit_cost }}{% if form.unit_cost.errors %}<div class="error">{{ form.unit_cost.errors|striptags }}</div>{% endif %}</div>
+  <div class="field"><label for="{{ form.production_time.id_for_label }}">Tempo de produção</label>{{ form.production_time }}{% if form.production_time.errors %}<div class="error">{{ form.production_time.errors|striptags }}</div>{% endif %}</div>
+  <div class="field"><label for="{{ form.print_time_min.id_for_label }}">Tempo de impressão (min/un)</label>{{ form.print_time_min }}{% if form.print_time_min.errors %}<div class="error">{{ form.print_time_min.errors|striptags }}</div>{% endif %}</div>
+  <div class="field"><label for="{{ form.qty_on_hand.id_for_label }}">Qtd em estoque</label>{{ form.qty_on_hand }}{% if form.qty_on_hand.errors %}<div class="error">{{ form.qty_on_hand.errors|striptags }}</div>{% endif %}</div>
   <div class="form-actions">
     <button class="btn btn-primary" type="submit">Salvar</button>
     <a class="btn" href="{% url 'estoque-componentes' %}">Cancelar</a>

--- a/templates/estoque/componentes_list.html
+++ b/templates/estoque/componentes_list.html
@@ -25,6 +25,7 @@
       <tr>
         <th style="width:160px">Código</th>
         <th>Nome</th>
+        <th>Material</th>
         <th class="right" style="width:120px">Estoque</th>
         <th style="width:60px"></th>
       </tr>
@@ -35,6 +36,7 @@
         <tr>
           <td class="mono">{{ c.code }}</td>
           <td>{{ c.name }}</td>
+          <td>{{ c.material }}</td>
           <td class="right">{{ c.inventory.qty_on_hand|default:"0" }}</td>
           <td class="right">
             <div class="menu-wrap">
@@ -51,7 +53,7 @@
         </tr>
         {% endfor %}
       {% else %}
-        <tr><td colspan="4" class="muted">Nenhum componente encontrado.</td></tr>
+        <tr><td colspan="5" class="muted">Nenhum componente encontrado.</td></tr>
       {% endif %}
     </tbody>
   </table>

--- a/templates/estoque/produtos_list.html
+++ b/templates/estoque/produtos_list.html
@@ -25,6 +25,7 @@
       <tr>
         <th style="width:160px">Código</th>
         <th>Nome</th>
+        <th>Materiais</th>
         <th class="right" style="width:120px">Estoque</th>
         <th class="right" style="width:140px">Tempo total (min)</th>
         <th class="right" style="width:140px">Custo total (R$)</th>
@@ -37,6 +38,7 @@
         <tr>
           <td class="mono">{{ row.obj.code }}</td>
           <td>{{ row.obj.name }}</td>
+          <td>{{ row.materials }}</td>
           <td class="right">{{ row.qty_on_hand|default:"0" }}</td>
           <td class="right">{{ row.total_time_min|floatformat:0 }}</td>
           <td class="right">{{ row.total_cost|floatformat:2 }}</td>
@@ -55,7 +57,7 @@
         </tr>
         {% endfor %}
       {% else %}
-        <tr><td colspan="6" class="muted">Nenhum produto encontrado.</td></tr>
+        <tr><td colspan="7" class="muted">Nenhum produto encontrado.</td></tr>
       {% endif %}
     </tbody>
   </table>


### PR DESCRIPTION
## Summary
- allow components to store material and production time
- show component materials across inventory and product lists
- fix component creation form and include production timing input

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not connect to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a38314cdf0832092d1a98b07369b02