### PR TITLE
Add BOM step to product creation and compute product cost

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -62,6 +62,14 @@ class Product(models.Model):
     def estimated_build_hours(self, quantity: int) -> str:
         return minutes_to_hhmm(self.bom_required_minutes(quantity))
 
+    @property
+    def total_cost(self) -> float:
+        """Custo total somando os componentes do produto."""
+        total = 0.0
+        for item in self.bom_items.select_related("component"):
+            total += float(item.component.unit_cost) * item.quantity
+        return total
+
 class BOMItem(models.Model):
     product = models.ForeignKey(Product, related_name="bom_items", on_delete=models.CASCADE)
     component = models.ForeignKey(Component, related_name="bom_items", on_delete=models.PROTECT)

--- a/core/test.py
+++ b/core/test.py
@@ -1,7 +1,48 @@
 from django.test import TestCase
 from django.urls import reverse
+from .models import Component, Product, BOMItem
 
 class SmokeTests(TestCase):
     def test_homepage(self):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
+
+
+class ProductBOMTests(TestCase):
+    def test_total_cost_with_components(self):
+        comp = Component.objects.create(code="C1", name="Comp", unit_cost=10)
+        prod = Product.objects.create(code="P1", name="Prod")
+        BOMItem.objects.create(product=prod, component=comp, quantity=6)
+        self.assertEqual(prod.total_cost, 60)
+
+    def test_product_creation_redirects_to_bom(self):
+        data = {
+            "code": "P1",
+            "name": "Prod",
+            "description": "",
+            "qty_on_hand": "0",
+        }
+        response = self.client.post(reverse("produtos-new"), data)
+        prod = Product.objects.get(code="P1")
+        self.assertRedirects(response, reverse("produtos-bom", args=[prod.pk]))
+
+    def test_add_component_via_view(self):
+        comp = Component.objects.create(code="C1", name="Comp", unit_cost=5)
+        prod = Product.objects.create(code="P1", name="Prod")
+        url = reverse("produtos-bom", args=[prod.pk])
+        data = {
+            "code": prod.code,
+            "name": prod.name,
+            "description": "",
+            "qty_on_hand": "0",
+            "bom_items-TOTAL_FORMS": "1",
+            "bom_items-INITIAL_FORMS": "0",
+            "bom_items-MIN_NUM_FORMS": "0",
+            "bom_items-MAX_NUM_FORMS": "1000",
+            "bom_items-0-component": str(comp.pk),
+            "bom_items-0-quantity": "6",
+        }
+        response = self.client.post(url, data)
+        self.assertRedirects(response, reverse("estoque-produtos"))
+        self.assertEqual(prod.bom_items.count(), 1)
+        self.assertEqual(prod.total_cost, 30)

--- a/mfgsite/urls.py
+++ b/mfgsite/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path("produtos/novo/", v.produtos_new, name="produtos-new"),
     path("produtos/<int:pk>/editar/", v.produtos_edit, name="produtos-edit"),
     path("produtos/<int:pk>/excluir/", v.produtos_delete, name="produtos-delete"),
+    path("produtos/<int:pk>/componentes/", v.produtos_bom, name="produtos-bom"),
 
     # Relatórios e Configurações
     path("relatorios/", v.relatorios, name="relatorios"),

--- a/templates/estoque/produtos_list.html
+++ b/templates/estoque/produtos_list.html
@@ -46,6 +46,7 @@
             <div class="menu-wrap">
               <button type="button" class="dots-btn" aria-haspopup="true" aria-expanded="false">⋯</button>
               <div class="menu">
+                <a href="{% url 'produtos-bom' row.obj.pk %}">Componentes</a>
                 <a href="{% url 'produtos-edit' row.obj.pk %}">Editar</a>
                 <form method="post" action="{% url 'produtos-delete' row.obj.pk %}">
                   {% csrf_token %}


### PR DESCRIPTION
## Summary
- allow adding components immediately after creating a product
- compute product total cost from components and show link to manage components
- add tests for BOM cost aggregation, view, and redirect after product creation

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a3eb5b6c148320a3bae4c5e29f211e