### PR TITLE
Fix delete field template error

### DIFF
--- a/templates/produtos_form.html
+++ b/templates/produtos_form.html
@@ -20,7 +20,6 @@
         <td>{{ f.quantity }}</td>
         <td class="right">
           {{ f.DELETE }}
-          {{ f.DELETE.as_widget(attrs={'class': 'delete-field'}) }}
           <div class="menu-wrap">
             <button type="button" class="dots-btn" aria-haspopup="true" aria-expanded="false">⋯</button>
             <div class="menu">
@@ -41,7 +40,6 @@
       <td>{{ formset.empty_form.quantity }}</td>
       <td class="right">
         {{ formset.empty_form.DELETE }}
-        {{ formset.empty_form.DELETE.as_widget(attrs={'class': 'delete-field'}) }}
         <div class="menu-wrap">
           <button type="button" class="dots-btn" aria-haspopup="true" aria-expanded="false">⋯</button>
           <div class="menu">
@@ -73,7 +71,6 @@
 .menu .danger{color:var(--danger)}
 .menu-wrap.open .menu{display:block}
 input[name$="-DELETE"]{display:none}
-.delete-field{display:none}
 </style>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- fix produto form template by removing invalid DELETE field widget call
- drop unused delete-field CSS rule

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c406668883209194a96709c1880f