### PR TITLE
feat: use off white background

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,27 +10,17 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     :root{
-      --bg:#f7f7f5; --card:#fff; --muted:#6b7280; --line:#ececec;
-
+      --bg:#F8F5EE; --card:#fff; --muted:#6b7280; --line:#ececec;
       --text:#000; --accent:#0052a5; --accent-600:#003b7a;
       --danger:#e11d48; --success:#16a34a;
       --sidebar:#001f3f; --sidebar-muted:#d1d5db;
-
-      --text:#111827; --accent:#0052a5; --accent-600:#003b7a;
-      --danger:#e11d48; --success:#16a34a;
-      --sidebar:#001f3f; --sidebar-muted:#d1d5db;
-      --bg:#001f3f; --bg-light:#0052a5; --card:#ffffff; --muted:#d1d5db; --line:#003b7a;
-      --text:#ffffff; --accent:#0052a5; --accent-600:#003b7a;
-      --danger:#e11d48; --success:#16a34a;
-      --sidebar:#0052a5; --sidebar-muted:#d1d5db;
-
     }
     *{box-sizing:border-box} html,body{height:100%}
     body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text)}
     a{color:inherit;text-decoration:none}
     .app{display:grid;grid-template-columns:260px 1fr; min-height:100vh}
-    .sidebar{background:var(--sidebar);color:var(--text);padding:18px 14px;display:flex;flex-direction:column}
-    .brand{display:flex;align-items:center;gap:10px;font-weight:700;margin-bottom:16px}
+    .sidebar{background:var(--sidebar);color:var(--sidebar-muted);padding:18px 14px;display:flex;flex-direction:column}
+    .brand{display:flex;align-items:center;gap:10px;font-weight:700;margin-bottom:16px;color:#fff;font-size:22px}
     .brand .dot{width:28px;height:28px;border-radius:6px;background:var(--accent);display:inline-block}
     nav a{display:block;padding:8px 10px;margin:2px 0;border-radius:8px;color:var(--sidebar-muted)}
     nav a:hover{background:var(--accent-600);color:#fff}
@@ -41,12 +31,12 @@
     .page-title{font-size:28px;font-weight:700}
     .page-actions{display:flex;gap:8px}
     .blocks{display:grid;grid-template-columns:repeat(12,1fr);gap:12px}
-    .block{grid-column:span 12;background:var(--card);border:1px solid var(--line);border-radius:12px;padding:16px;color:var(--bg)}
+    .block{grid-column:span 12;background:var(--card);border:1px solid var(--line);border-radius:12px;padding:16px;color:var(--text)}
     @media(min-width:900px){.col-6{grid-column:span 6}.col-4{grid-column:span 4}.col-3{grid-column:span 3}}
     .stat-title{font-size:12px;color:var(--muted)}
     .stat-value{font-size:26px;font-weight:700;margin-top:6px}
     .muted{color:var(--muted)}
-    .btn{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line);background:#fff;color:var(--bg);border-radius:8px;padding:8px 12px;font-weight:500}
+    .btn{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line);background:#fff;color:var(--text);border-radius:8px;padding:8px 12px;font-weight:500}
     .btn:hover{background:#fafafa}
     .btn-primary{background:var(--accent);border-color:var(--accent);color:#fff}
     .btn-primary:hover{background:var(--accent-600)}
@@ -76,7 +66,7 @@
       <div class="brand"><span class="dot"></span> Print management</div>
       <nav>
         <a href="{% url 'dashboard' %}" id="nav-dash" {% if request.resolver_match.url_name == 'dashboard' %}class="active"{% endif %}>Dashboard</a>
-        <div class="muted" style="padding:8px 10px 4px;font-size:12px;">Estoque</div>
+        <div class="muted" style="padding:8px 10px 4px;font-size:12px;color:var(--sidebar-muted);">Estoque</div>
         <div class="subnav">
           <a href="{% url 'estoque-componentes' %}" id="nav-comp" {% if request.resolver_match.url_name == 'estoque-componentes' %}class="active"{% endif %}>Componentes</a>
           <a href="{% url 'estoque-produtos' %}" id="nav-prod" {% if request.resolver_match.url_name == 'estoque-produtos' %}class="active"{% endif %}>Produtos</a>

--- a/templates/estoque/componentes_list.html
+++ b/templates/estoque/componentes_list.html
@@ -72,24 +72,7 @@
 .btn-primary{background:var(--accent);color:#fff;border-color:var(--accent)}
 .search-bar{display:flex;gap:8px;margin:0 0 12px}
 .search-bar input{flex:1;border:1px solid var(--line);border-radius:8px;padding:8px 12px;background:#fff;color:var(--text)}
-
 .notion-card{background:#fff;border:1px solid var(--line);border-radius:12px;padding:8px;color:var(--text)}
-
-.actions{display:flex;gap:8px}
-.btn{border:1px solid var(--line);background:#fff;color:var(--text);padding:8px 12px;border-radius:8px}
-.btn-primary{background:var(--accent);color:#fff;border-color:var(--accent)}
-.search-bar{display:flex;gap:8px;margin:0 0 12px}
-.search-bar input{flex:1;border:1px solid var(--line);border-radius:8px;padding:8px 12px;background:#fff;color:var(--text)}
-
-.notion-card{background:#fff;border:1px solid var(--line);border-radius:12px;padding:8px;color:var(--text)}
-.muted{color:var(--muted)}
-.actions{display:flex;gap:8px}
-.btn{border:1px solid var(--line);background:#fff;color:var(--bg);padding:8px 12px;border-radius:8px}
-.btn-primary{background:var(--accent);color:#fff;border-color:var(--accent)}
-.search-bar{display:flex;gap:8px;margin:0 0 12px}
-.search-bar input{flex:1;border:1px solid var(--line);border-radius:8px;padding:8px 12px;background:#fff;color:var(--bg)}
-
-.notion-card{background:#fff;border:1px solid var(--line);border-radius:12px;padding:8px;color:var(--bg)}
 
 .nt-table{width:100%;border-collapse:separate;border-spacing:0}
 .nt-table thead th{font-size:12px;color:var(--muted);font-weight:600;text-align:left;padding:10px}
@@ -101,19 +84,9 @@
 .dots-btn{border:1px solid transparent;background:transparent;font-size:20px;line-height:1;border-radius:8px;padding:2px 6px;cursor:pointer}
 .dots-btn:focus{outline:none;border-color:var(--line)}
 .menu{position:absolute;right:0;top:calc(100% + 6px);background:#fff;border:1px solid var(--line);border-radius:10px;min-width:160px;box-shadow:0 12px 24px rgba(0,0,0,0.08);display:none;z-index:20;padding:6px}
-d
 .menu a{display:block;padding:8px 10px;text-decoration:none;color:var(--text);border-radius:8px}
 .menu a:hover{background:#f3f4f6}
 .menu .menu-link{display:block;width:100%;text-align:left;padding:8px 10px;border:0;background:transparent;border-radius:8px;cursor:pointer;color:var(--text)}
-
-
-.menu a{display:block;padding:8px 10px;text-decoration:none;color:var(--text);border-radius:8px}
-.menu a:hover{background:#f3f4f6}
-.menu .menu-link{display:block;width:100%;text-align:left;padding:8px 10px;border:0;background:transparent;border-radius:8px;cursor:pointer;color:var(--text)}
-
-.menu a{display:block;padding:8px 10px;text-decoration:none;color:var(--bg);border-radius:8px}
-.menu a:hover{background:#f3f4f6}
-.menu .menu-link{display:block;width:100%;text-align:left;padding:8px 10px;border:0;background:transparent;border-radius:8px;cursor:pointer;color:var(--bg)}
 
 
 .menu .menu-link:hover{background:#f3f4f6}

--- a/templates/estoque/produtos_list.html
+++ b/templates/estoque/produtos_list.html
@@ -68,60 +68,25 @@
 <style>
 .page-header{display:flex;align-items:flex-end;justify-content:space-between;margin:8px 0 16px}
 .page-title{font-size:24px;font-weight:700;margin:0}
-
 .muted{color:var(--muted)}
-
 .actions{display:flex;gap:8px}
 .btn{border:1px solid var(--line);background:#fff;color:var(--text);padding:8px 12px;border-radius:8px}
 .btn-primary{background:var(--accent);color:#fff;border-color:var(--accent)}
 .search-bar{display:flex;gap:8px;margin:0 0 12px}
 .search-bar input{flex:1;border:1px solid var(--line);border-radius:8px;padding:8px 12px;background:#fff;color:var(--text)}
-
 .notion-card{background:#fff;border:1px solid var(--line);border-radius:12px;padding:8px;color:var(--text)}
-
-.actions{display:flex;gap:8px}
-.btn{border:1px solid var(--line);background:#fff;color:var(--text);padding:8px 12px;border-radius:8px}
-.btn-primary{background:var(--accent);color:#fff;border-color:var(--accent)}
-.search-bar{display:flex;gap:8px;margin:0 0 12px}
-.search-bar input{flex:1;border:1px solid var(--line);border-radius:8px;padding:8px 12px;background:#fff;color:var(--text)}
-
-.notion-card{background:#fff;border:1px solid var(--line);border-radius:12px;padding:8px;color:var(--text)}
-
-.muted{color:var(--muted)}
-.actions{display:flex;gap:8px}
-.btn{border:1px solid var(--line);background:#fff;color:var(--bg);padding:8px 12px;border-radius:8px}
-.btn-primary{background:var(--accent);color:#fff;border-color:var(--accent)}
-.search-bar{display:flex;gap:8px;margin:0 0 12px}
-.search-bar input{flex:1;border:1px solid var(--line);border-radius:8px;padding:8px 12px;background:#fff;color:var(--bg)}
-
-.notion-card{background:#fff;border:1px solid var(--line);border-radius:12px;padding:8px;color:var(--bg)}
-
-
 .nt-table{width:100%;border-collapse:separate;border-spacing:0}
 .nt-table thead th{font-size:12px;color:var(--muted);font-weight:600;text-align:left;padding:10px}
 .nt-table tbody td{padding:10px;border-top:1px solid var(--line)}
 .right{text-align:right}
 .mono{font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace}
-
 .menu-wrap{position:relative;display:inline-block}
 .dots-btn{border:1px solid transparent;background:transparent;font-size:20px;line-height:1;border-radius:8px;padding:2px 6px;cursor:pointer}
 .dots-btn:focus{outline:none;border-color:var(--line)}
 .menu{position:absolute;right:0;top:calc(100% + 6px);background:#fff;border:1px solid var(--line);border-radius:10px;min-width:160px;box-shadow:0 12px 24px rgba(0,0,0,0.08);display:none;z-index:20;padding:6px}
-
 .menu a{display:block;padding:8px 10px;text-decoration:none;color:var(--text);border-radius:8px}
 .menu a:hover{background:#f3f4f6}
 .menu .menu-link{display:block;width:100%;text-align:left;padding:8px 10px;border:0;background:transparent;border-radius:8px;cursor:pointer;color:var(--text)}
-
-
-.menu a{display:block;padding:8px 10px;text-decoration:none;color:var(--text);border-radius:8px}
-.menu a:hover{background:#f3f4f6}
-.menu .menu-link{display:block;width:100%;text-align:left;padding:8px 10px;border:0;background:transparent;border-radius:8px;cursor:pointer;color:var(--text)}
-
-.menu a{display:block;padding:8px 10px;text-decoration:none;color:var(--bg);border-radius:8px}
-.menu a:hover{background:#f3f4f6}
-.menu .menu-link{display:block;width:100%;text-align:left;padding:8px 10px;border:0;background:transparent;border-radius:8px;cursor:pointer;color:var(--bg)}
-
-
 .menu .menu-link:hover{background:#f3f4f6}
 .menu .danger{color:var(--danger)}
 .menu-wrap.open .menu{display:block}

--- a/templates/produtos_form.html
+++ b/templates/produtos_form.html
@@ -64,17 +64,9 @@
 .dots-btn{border:1px solid transparent;background:transparent;font-size:20px;line-height:1;border-radius:8px;padding:2px 6px;cursor:pointer}
 .dots-btn:focus{outline:none;border-color:var(--line)}
 .menu{position:absolute;right:0;top:calc(100% + 6px);background:#fff;border:1px solid var(--line);border-radius:10px;min-width:160px;box-shadow:0 12px 24px rgba(0,0,0,0.08);display:none;z-index:20;padding:6px}
-.menu a{display:block;padding:8px 10px;text-decoration:none;color:var(--bg);border-radius:8px}
+.menu a{display:block;padding:8px 10px;text-decoration:none;color:var(--text);border-radius:8px}
 .menu a:hover{background:#f3f4f6}
-
 .menu .menu-link{display:block;width:100%;text-align:left;padding:8px 10px;border:0;background:transparent;border-radius:8px;cursor:pointer;color:var(--text)}
-
-
-.menu .menu-link{display:block;width:100%;text-align:left;padding:8px 10px;border:0;background:transparent;border-radius:8px;cursor:pointer;color:var(--text)}
-
-.menu .menu-link{display:block;width:100%;text-align:left;padding:8px 10px;border:0;background:transparent;border-radius:8px;cursor:pointer;color:var(--bg)}
-
-
 .menu .menu-link:hover{background:#f3f4f6}
 .menu .danger{color:var(--danger)}
 .menu-wrap.open .menu{display:block}


### PR DESCRIPTION
## Summary
- set global background to off white
- fix text contrast and sidebar brand styling
- ensure consistent dark text across estoque and product templates

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f5c530788320aaa21934adea716b