### PR TITLE
Add production tab for creating and tracking orders

### DIFF
--- a/mfgsite/urls.py
+++ b/mfgsite/urls.py
@@ -22,6 +22,9 @@ urlpatterns = [
     path("produtos/<int:pk>/editar/", v.produtos_edit, name="produtos-edit"),
     path("produtos/<int:pk>/excluir/", v.produtos_delete, name="produtos-delete"),
 
+    # Produção
+    path("producao/", v.producao, name="producao"),
+
     # Relatórios e Configurações
     path("relatorios/", v.relatorios, name="relatorios"),
     path("configuracoes/", v.configuracoes, name="configuracoes"),

--- a/templates/base.html
+++ b/templates/base.html
@@ -74,6 +74,7 @@
           <a href="{% url 'estoque-componentes' %}" id="nav-comp" {% if request.resolver_match.url_name == 'estoque-componentes' %}class="active"{% endif %}>Componentes</a>
           <a href="{% url 'estoque-produtos' %}" id="nav-prod" {% if request.resolver_match.url_name == 'estoque-produtos' %}class="active"{% endif %}>Produtos</a>
         </div>
+        <a href="{% url 'producao' %}" id="nav-producao" {% if request.resolver_match.url_name == 'producao' %}class="active"{% endif %}>Produção</a>
         <a href="{% url 'relatorios' %}" id="nav-rel" {% if request.resolver_match.url_name == 'relatorios' %}class="active"{% endif %}>Relatórios</a>
         <a href="{% url 'configuracoes' %}" id="nav-config" {% if request.resolver_match.url_name == 'configuracoes' %}class="active"{% endif %}>Configurações</a>
       </nav>

--- a/templates/producao.html
+++ b/templates/producao.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Produção{% endblock %}
+{% block content %}
+<div class="page-header"><div class="page-title">Produção</div></div>
+<form method="post" class="block form">
+  {% csrf_token %}
+  <div class="field"><label for="{{ form.product.id_for_label }}">Produto</label>{{ form.product }}</div>
+  <div class="field"><label for="{{ form.quantity.id_for_label }}">Quantidade</label>{{ form.quantity }}</div>
+  <div class="form-actions">
+    <button class="btn btn-primary" type="submit">Adicionar</button>
+  </div>
+</form>
+<div class="page-title" style="font-size:20px;margin-top:18px">Produções em andamento</div>
+<div class="block">
+  <table>
+    <thead><tr><th>Produto</th><th class="right">Quantidade</th><th class="right">Tempo total</th></tr></thead>
+    <tbody>
+    {% if orders %}
+      {% for o in orders %}
+      <tr>
+        <td>{{ o.obj.product.code }} — {{ o.obj.product.name }}</td>
+        <td class="right">{{ o.obj.quantity }}</td>
+        <td class="right">{{ o.total_time }}</td>
+      </tr>
+      {% endfor %}
+    {% else %}
+      <tr><td colspan="3" class="muted">Nenhuma produção em andamento.</td></tr>
+    {% endif %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add view and template for production page with product/quantity form
- list open production orders with total time required
- add navigation link and route for production page

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68aa5a954c28832083e9f130d929b876