### PR TITLE
Fix invalid empty tag in producao template

### DIFF
--- a/templates/producao.html
+++ b/templates/producao.html
@@ -24,7 +24,6 @@
 <div class="page-title" style="font-size:20px;margin-top:18px">Produções em andamento</div>
 <div class="block">
   <table>
-
     <thead>
       <tr>
         <th>Produto</th>
@@ -34,7 +33,6 @@
       </tr>
     </thead>
     <tbody>
-
     {% if orders %}
       {% for o in orders %}
         <tr>
@@ -80,117 +78,8 @@
       {% endfor %}
     {% else %}
       <tr><td colspan="4" class="muted">Nenhuma produção em andamento.</td></tr>
-
-
-    {% for o in orders %}
-      <tr>
-
-    <thead><tr><th>Produto</th><th class="right">Quantidade</th><th class="right">Tempo total</th><th></th></tr></thead>
-    <tbody>
-    {% for o in orders %}
-      <tr>
-
-    <thead><tr><th>Produto</th><th class="right">Quantidade</th><th class="right">Tempo total</th><th></th></tr></thead>
-
-    <thead><tr><th>Produto</th><th class="right">Quantidade</th><th class="right">Tempo total</th></tr></thead>
-
-    <tbody>
-    {% if orders %}
-      {% for o in orders %}
-      <tr>
-
-
-        <td colspan="4">
-          <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:8px;">
-            <details style="flex:1;">
-              <summary style="display:flex;justify-content:space-between;">
-                <span>{{ o.obj.product.code }} — {{ o.obj.product.name }}</span>
-                <span class="right" style="min-width:80px;text-align:right;">{{ o.obj.quantity }}</span>
-                <span class="right" style="min-width:80px;text-align:right;">{{ o.total_time }}</span>
-              </summary>
-              <table style="width:100%;margin-top:8px;">
-                <thead>
-
-                  <tr>
-                    <th>Componente</th>
-                    <th class="right">Qtd total</th>
-                    <th class="right">Tempo total</th>
-                    <th class="right">Custo total</th>
-                  </tr>
-
-                  <tr><th>Componente</th><th class="right">Qtd total</th><th class="right">Tempo total</th><th class="right">Custo total</th></tr>
-
-                </thead>
-                <tbody>
-                  {% for c in o.components %}
-                  <tr>
-                    <td>{{ c.component.code }} — {{ c.component.name }}</td>
-                    <td class="right">{{ c.required_qty }}</td>
-                    <td class="right">{{ c.time_total }}</td>
-                    <td class="right">R$ {{ c.cost_total|floatformat:2 }}</td>
-                  </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
-            </details>
-            <div class="action-menu">
-              <span>⋮</span>
-              <div class="menu">
-                <a href="{% url 'producao-edit' o.obj.pk %}">Editar</a>
-                <a href="{% url 'producao-delete' o.obj.pk %}">Excluir</a>
-              </div>
-            </div>
-          </div>
-        </td>
-      </tr>
-
-    {% empty %}
-      <tr><td colspan="4" class="muted">Nenhuma produção em andamento.</td></tr>
-    {% endfor %}
-
-
-    {% empty %}
-      <tr><td colspan="4" class="muted">Nenhuma produção em andamento.</td></tr>
-    {% endfor %}
-
-      {% endfor %}
-    {% else %}
-      <tr><td colspan="4" class="muted">Nenhuma produção em andamento.</td></tr>
-        <td colspan="3">
-          <details>
-            <summary style="display:flex;justify-content:space-between;">
-              <span>{{ o.obj.product.code }} — {{ o.obj.product.name }}</span>
-              <span class="right" style="min-width:80px;text-align:right;">{{ o.obj.quantity }}</span>
-              <span class="right" style="min-width:80px;text-align:right;">{{ o.total_time }}</span>
-            </summary>
-            <table style="width:100%;margin-top:8px;">
-              <thead>
-                <tr><th>Componente</th><th class="right">Qtd total</th><th class="right">Tempo total</th><th class="right">Custo total</th></tr>
-              </thead>
-              <tbody>
-                {% for c in o.components %}
-                <tr>
-                  <td>{{ c.component.code }} — {{ c.component.name }}</td>
-                  <td class="right">{{ c.required_qty }}</td>
-                  <td class="right">{{ c.time_total }}</td>
-                  <td class="right">R$ {{ c.cost_total|floatformat:2 }}</td>
-                </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </details>
-        </td>
-        <td>{{ o.obj.product.code }} — {{ o.obj.product.name }}</td>
-        <td class="right">{{ o.obj.quantity }}</td>
-        <td class="right">{{ o.total_time }}</td>
-      </tr>
-      {% endfor %}
-    {% else %}
-      <tr><td colspan="3" class="muted">Nenhuma produção em andamento.</td></tr>
-
     {% endif %}
     </tbody>
   </table>
 </div>
 {% endblock %}
-


### PR DESCRIPTION
## Summary
- Simplify producao.html table rendering
- Remove stray `{% empty %}` tags and duplicated markup

## Testing
- `python -m pytest`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68aa6ecdb80083209b375461b1334350