### PR TITLE
fix: avoid duplicate production order entries

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -306,9 +306,6 @@ def producao(request):
         )
 
 
-        orders.append({"obj": op, "total_time": minutes_to_hhmm(total_min)})
-
-
     return render(request, "producao.html", {"form": form, "orders": orders})
 
 


### PR DESCRIPTION
## Summary
- prevent duplicate production orders from showing on the in-progress list

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68aa702172e883209ec36f4cd1b14933