### PR TITLE
Add print task scheduling with multi-printer support

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -6,6 +6,7 @@ from .models import (
     ProductionOrder,
     ProductionLog,
     Printer,
+    PrintTask,
     WorkOrder,
 )
 
@@ -38,6 +39,12 @@ class ProductionLogAdmin(admin.ModelAdmin):
 @admin.register(Printer)
 class PrinterAdmin(admin.ModelAdmin):
     list_display = ("name", "is_active", "speed_factor", "tags")
+
+
+@admin.register(PrintTask)
+class PrintTaskAdmin(admin.ModelAdmin):
+    list_display = ("order", "component", "printer", "quantity", "status")
+    list_filter = ("component", "printer", "status")
 
 
 @admin.register(WorkOrder)

--- a/core/migrations/0005_printtask.py
+++ b/core/migrations/0005_printtask.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import django.core.validators
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('core', '0004_printer_component_base_time_min_component_batch_size_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PrintTask',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('quantity', models.PositiveIntegerField(default=1, validators=[django.core.validators.MinValueValidator(1)])),
+                ('status', models.CharField(default='pending', max_length=20)),
+                ('component', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='core.component')),
+                ('order', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='print_tasks', to='core.productionorder')),
+                ('printer', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='core.printer')),
+            ],
+        ),
+    ]

--- a/core/print_tasks.py
+++ b/core/print_tasks.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from typing import List, Tuple
+from django.core.exceptions import ValidationError
+from .models import ProductionOrder, Component, PrintTask
+
+
+@dataclass
+class TaskInfo:
+    task: PrintTask
+    time_h: float
+
+
+@dataclass
+class ComponentInfo:
+    component: Component
+    t_piece_h: float
+    required_qty: int
+    assigned_qty: int
+    remaining_qty: int
+    capacity: float
+    time_h: float
+    remaining_time_h: float
+    tasks: List[TaskInfo]
+
+
+def calculate_order_times(order: ProductionOrder) -> Tuple[List[ComponentInfo], float]:
+    """Calcula tempos agregados de impressão para uma ordem de produção."""
+    stats: List[ComponentInfo] = []
+    for bom in order.product.bom_items.select_related("component"):
+        comp = bom.component
+        required = order.required_for_component(comp)
+        t_piece = (comp.print_time_min or 0) / 60.0
+        tasks = list(order.print_tasks.filter(component=comp).select_related("printer"))
+        assigned = sum(t.quantity for t in tasks)
+        capacity = sum((t.printer.speed_factor or 1.0) for t in tasks)
+        task_infos: List[TaskInfo] = []
+        for t in tasks:
+            speed = t.printer.speed_factor or 1.0
+            task_time = (t.quantity * t_piece) / speed
+            task_infos.append(TaskInfo(t, task_time))
+        comp_time = (assigned * t_piece) / capacity if capacity > 0 else 0.0
+        remaining_qty = max(required - assigned, 0)
+        remaining_time = remaining_qty * t_piece
+        if assigned > required:
+            raise ValidationError(
+                f"A soma das quantidades das tarefas para o componente {comp.name} ({assigned}) excede a quantidade necessária ({required}). Ajuste as tarefas."
+            )
+        stats.append(
+            ComponentInfo(
+                component=comp,
+                t_piece_h=t_piece,
+                required_qty=required,
+                assigned_qty=assigned,
+                remaining_qty=remaining_qty,
+                capacity=capacity,
+                time_h=comp_time,
+                remaining_time_h=remaining_time,
+                tasks=task_infos,
+            )
+        )
+    total = max((s.time_h for s in stats), default=0.0)
+    return stats, total

--- a/core/test_print_tasks.py
+++ b/core/test_print_tasks.py
@@ -1,0 +1,100 @@
+from django.test import TestCase
+from django.core.exceptions import ValidationError
+from core.models import (
+    Component,
+    Product,
+    BOMItem,
+    ProductionOrder,
+    Printer,
+    PrintTask,
+)
+from core.print_tasks import calculate_order_times
+
+
+class PrintTaskCalculationTests(TestCase):
+    def _setup_product(self):
+        product = Product.objects.create(code="P1", name="Prod")
+        return product
+
+    def test_example1_single_component_parallel(self):
+        product = self._setup_product()
+        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=12)
+        BOMItem.objects.create(product=product, component=comp_a, quantity=50)
+        order = ProductionOrder.objects.create(product=product, quantity=1)
+        printers = [
+            Printer.objects.create(name=f"P{i}", is_active=True, speed_factor=1.0)
+            for i in range(5)
+        ]
+        for p in printers:
+            PrintTask.objects.create(order=order, component=comp_a, printer=p, quantity=10)
+        stats, total = calculate_order_times(order)
+        self.assertAlmostEqual(total, 2.0)
+        comp_stat = stats[0]
+        self.assertEqual(comp_stat.assigned_qty, 50)
+        self.assertAlmostEqual(comp_stat.capacity, 5.0)
+        self.assertAlmostEqual(comp_stat.time_h, 2.0)
+        self.assertEqual(comp_stat.remaining_qty, 0)
+
+    def test_example2_two_components(self):
+        product = self._setup_product()
+        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=12)
+        comp_b = Component.objects.create(code="B", name="CompB", print_time_min=3)
+        BOMItem.objects.create(product=product, component=comp_a, quantity=50)
+        BOMItem.objects.create(product=product, component=comp_b, quantity=20)
+        order = ProductionOrder.objects.create(product=product, quantity=1)
+        printers_a = [
+            Printer.objects.create(name=f"PA{i}", is_active=True, speed_factor=1.0)
+            for i in range(5)
+        ]
+        printers_b = [
+            Printer.objects.create(name=f"PB{i}", is_active=True, speed_factor=1.0)
+            for i in range(5)
+        ]
+        for p in printers_a:
+            PrintTask.objects.create(order=order, component=comp_a, printer=p, quantity=10)
+        for p in printers_b:
+            PrintTask.objects.create(order=order, component=comp_b, printer=p, quantity=4)
+        stats, total = calculate_order_times(order)
+        self.assertAlmostEqual(total, 2.0)
+        stat_a = next(s for s in stats if s.component == comp_a)
+        stat_b = next(s for s in stats if s.component == comp_b)
+        self.assertAlmostEqual(stat_a.time_h, 2.0)
+        self.assertAlmostEqual(stat_b.time_h, 0.2)
+
+    def test_example3_partial_with_remaining(self):
+        product = self._setup_product()
+        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=12)
+        BOMItem.objects.create(product=product, component=comp_a, quantity=50)
+        order = ProductionOrder.objects.create(product=product, quantity=1)
+        printers = [
+            Printer.objects.create(name=f"P{i}", is_active=True, speed_factor=1.0)
+            for i in range(2)
+        ]
+        for p in printers:
+            PrintTask.objects.create(order=order, component=comp_a, printer=p, quantity=10)
+        stats, total = calculate_order_times(order)
+        self.assertAlmostEqual(total, 2.0)
+        comp_stat = stats[0]
+        self.assertEqual(comp_stat.assigned_qty, 20)
+        self.assertEqual(comp_stat.remaining_qty, 30)
+        self.assertAlmostEqual(comp_stat.remaining_time_h, 6.0)
+
+    def test_quantity_exceed_validation(self):
+        product = self._setup_product()
+        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=12)
+        BOMItem.objects.create(product=product, component=comp_a, quantity=50)
+        order = ProductionOrder.objects.create(product=product, quantity=1)
+        p1 = Printer.objects.create(name="P1", is_active=True, speed_factor=1.0)
+        p2 = Printer.objects.create(name="P2", is_active=True, speed_factor=1.0)
+        PrintTask.objects.create(order=order, component=comp_a, printer=p1, quantity=40)
+        with self.assertRaises(ValidationError):
+            PrintTask.objects.create(order=order, component=comp_a, printer=p2, quantity=20)
+
+    def test_inactive_printer_validation(self):
+        product = self._setup_product()
+        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=12)
+        BOMItem.objects.create(product=product, component=comp_a, quantity=10)
+        order = ProductionOrder.objects.create(product=product, quantity=1)
+        printer = Printer.objects.create(name="PX", is_active=False, speed_factor=1.0)
+        with self.assertRaises(ValidationError):
+            PrintTask.objects.create(order=order, component=comp_a, printer=printer, quantity=5)


### PR DESCRIPTION
## Summary
- add PrintTask model to manage per-printer quantities and enforce limits
- implement calculation service for task and component times in parallel
- cover scenarios with unit tests for scheduling and validations

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ada74c83748320b09b2a66024e4169