### PR TITLE
Implement parallel remaining time calculations

### DIFF
--- a/core/print_tasks.py
+++ b/core/print_tasks.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from django.core.exceptions import ValidationError
 from .models import ProductionOrder, Component, PrintTask
 
@@ -15,11 +15,10 @@ class ComponentInfo:
     component: Component
     t_piece_h: float
     required_qty: int
-    assigned_qty: int
+    done_qty: int
     remaining_qty: int
     capacity: float
-    time_h: float
-    remaining_time_h: float
+    remaining_time_h: Optional[float]
     tasks: List[TaskInfo]
 
 
@@ -30,33 +29,42 @@ def calculate_order_times(order: ProductionOrder) -> Tuple[List[ComponentInfo], 
         comp = bom.component
         required = order.required_for_component(comp)
         t_piece = (comp.print_time_min or 0) / 60.0
-        tasks = list(order.print_tasks.filter(component=comp).select_related("printer"))
+        done = order.printed_for_component(comp)
+        remaining_qty = max(required - done, 0)
+        tasks = list(
+            order.print_tasks.filter(component=comp, printer__is_active=True).select_related("printer")
+        )
         assigned = sum(t.quantity for t in tasks)
         capacity = sum((t.printer.speed_factor or 1.0) for t in tasks)
+        if assigned > required:
+            raise ValidationError(
+                f"A soma das quantidades das tarefas para o componente {comp.name} ({assigned}) excede a quantidade necessária ({required}). Ajuste as tarefas."
+            )
         task_infos: List[TaskInfo] = []
         for t in tasks:
             speed = t.printer.speed_factor or 1.0
             task_time = (t.quantity * t_piece) / speed
             task_infos.append(TaskInfo(t, task_time))
-        comp_time = (assigned * t_piece) / capacity if capacity > 0 else 0.0
-        remaining_qty = max(required - assigned, 0)
-        remaining_time = remaining_qty * t_piece
-        if assigned > required:
-            raise ValidationError(
-                f"A soma das quantidades das tarefas para o componente {comp.name} ({assigned}) excede a quantidade necessária ({required}). Ajuste as tarefas."
-            )
+        if remaining_qty > 0 and capacity > 0:
+            remaining_time = (remaining_qty * t_piece) / capacity
+        elif remaining_qty > 0:
+            remaining_time = None
+        else:
+            remaining_time = 0.0
         stats.append(
             ComponentInfo(
                 component=comp,
                 t_piece_h=t_piece,
                 required_qty=required,
-                assigned_qty=assigned,
+                done_qty=done,
                 remaining_qty=remaining_qty,
                 capacity=capacity,
-                time_h=comp_time,
                 remaining_time_h=remaining_time,
                 tasks=task_infos,
             )
         )
-    total = max((s.time_h for s in stats), default=0.0)
+    total = max(
+        (s.remaining_time_h for s in stats if s.remaining_time_h is not None),
+        default=0.0,
+    )
     return stats, total

--- a/core/test_print_tasks.py
+++ b/core/test_print_tasks.py
@@ -18,27 +18,30 @@ class PrintTaskCalculationTests(TestCase):
 
     def test_example1_single_component_parallel(self):
         product = self._setup_product()
-        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=12)
-        BOMItem.objects.create(product=product, component=comp_a, quantity=50)
+        # t_piece = 50 min => 0.8333h, required qty 6
+        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=50)
+        BOMItem.objects.create(product=product, component=comp_a, quantity=6)
         order = ProductionOrder.objects.create(product=product, quantity=1)
-        printers = [
-            Printer.objects.create(name=f"P{i}", is_active=True, speed_factor=1.0)
-            for i in range(5)
-        ]
-        for p in printers:
-            PrintTask.objects.create(order=order, component=comp_a, printer=p, quantity=10)
+        p1 = Printer.objects.create(name="P1", is_active=True, speed_factor=1.0)
+        p2 = Printer.objects.create(name="P2", is_active=True, speed_factor=1.0)
+        PrintTask.objects.create(order=order, component=comp_a, printer=p1, quantity=3)
+        PrintTask.objects.create(order=order, component=comp_a, printer=p2, quantity=3)
         stats, total = calculate_order_times(order)
-        self.assertAlmostEqual(total, 2.0)
+        self.assertAlmostEqual(total, 2.5)
         comp_stat = stats[0]
-        self.assertEqual(comp_stat.assigned_qty, 50)
-        self.assertAlmostEqual(comp_stat.capacity, 5.0)
-        self.assertAlmostEqual(comp_stat.time_h, 2.0)
-        self.assertEqual(comp_stat.remaining_qty, 0)
+        self.assertEqual(comp_stat.required_qty, 6)
+        self.assertEqual(comp_stat.done_qty, 0)
+        self.assertEqual(comp_stat.remaining_qty, 6)
+        self.assertAlmostEqual(comp_stat.capacity, 2.0)
+        self.assertAlmostEqual(comp_stat.remaining_time_h, 2.5)
+        self.assertEqual(len(comp_stat.tasks), 2)
+        for t in comp_stat.tasks:
+            self.assertAlmostEqual(t.time_h, 2.5)
 
     def test_example2_two_components(self):
         product = self._setup_product()
-        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=12)
-        comp_b = Component.objects.create(code="B", name="CompB", print_time_min=3)
+        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=12)  # 0.2h
+        comp_b = Component.objects.create(code="B", name="CompB", print_time_min=3)   # 0.05h
         BOMItem.objects.create(product=product, component=comp_a, quantity=50)
         BOMItem.objects.create(product=product, component=comp_b, quantity=20)
         order = ProductionOrder.objects.create(product=product, quantity=1)
@@ -58,26 +61,27 @@ class PrintTaskCalculationTests(TestCase):
         self.assertAlmostEqual(total, 2.0)
         stat_a = next(s for s in stats if s.component == comp_a)
         stat_b = next(s for s in stats if s.component == comp_b)
-        self.assertAlmostEqual(stat_a.time_h, 2.0)
-        self.assertAlmostEqual(stat_b.time_h, 0.2)
+        self.assertAlmostEqual(stat_a.remaining_time_h, 2.0)
+        self.assertAlmostEqual(stat_b.remaining_time_h, 0.2)
 
-    def test_example3_partial_with_remaining(self):
+    def test_component_without_capacity(self):
         product = self._setup_product()
-        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=12)
-        BOMItem.objects.create(product=product, component=comp_a, quantity=50)
+        comp_a = Component.objects.create(code="A", name="CompA", print_time_min=6)  # 0.1h
+        comp_b = Component.objects.create(code="B", name="CompB", print_time_min=4)  # ~0.0667h
+        comp_c = Component.objects.create(code="C", name="CompC", print_time_min=6)  # 0.1h
+        BOMItem.objects.create(product=product, component=comp_a, quantity=10)
+        BOMItem.objects.create(product=product, component=comp_b, quantity=10)
+        BOMItem.objects.create(product=product, component=comp_c, quantity=10)
         order = ProductionOrder.objects.create(product=product, quantity=1)
-        printers = [
-            Printer.objects.create(name=f"P{i}", is_active=True, speed_factor=1.0)
-            for i in range(2)
-        ]
-        for p in printers:
-            PrintTask.objects.create(order=order, component=comp_a, printer=p, quantity=10)
+        p1 = Printer.objects.create(name="PA", is_active=True, speed_factor=1.0)
+        p2 = Printer.objects.create(name="PB", is_active=True, speed_factor=1.0)
+        PrintTask.objects.create(order=order, component=comp_a, printer=p1, quantity=10)
+        PrintTask.objects.create(order=order, component=comp_b, printer=p2, quantity=10)
         stats, total = calculate_order_times(order)
-        self.assertAlmostEqual(total, 2.0)
-        comp_stat = stats[0]
-        self.assertEqual(comp_stat.assigned_qty, 20)
-        self.assertEqual(comp_stat.remaining_qty, 30)
-        self.assertAlmostEqual(comp_stat.remaining_time_h, 6.0)
+        self.assertAlmostEqual(total, 1.0)
+        stat_c = next(s for s in stats if s.component == comp_c)
+        self.assertIsNone(stat_c.remaining_time_h)
+        self.assertEqual(stat_c.capacity, 0)
 
     def test_quantity_exceed_validation(self):
         product = self._setup_product()


### PR DESCRIPTION
## Summary
- compute component and product remaining times considering printer parallelism
- drop per-task component remaining time display, expose parallel remaining time per component
- add tests for parallel and zero-capacity scenarios

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68adaa03bfa48320a548bd0b8e2bd402