### PR TITLE
Add remaining product time in print dashboard

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -136,6 +136,21 @@ class ProductionOrder(models.Model):
         rem = max(0, req - printed)
         return rem * component.print_time_min
 
+    def time_remaining_minutes(self) -> int:
+        """Tempo restante agregado (minutos) para concluir a ordem."""
+        items = list(self.product.bom_items.select_related("component"))
+        if not items:
+            return 0
+        times = [
+            self.time_remaining_minutes_for_component(item.component)
+            for item in items
+        ]
+        return max(times) if times else 0
+
+    @property
+    def time_remaining_hhmm(self) -> str:
+        return minutes_to_hhmm(self.time_remaining_minutes())
+
     @property
     def progress_percent(self) -> float:
         # média ponderada por quantidade requerida de cada componente

--- a/core/test_time_remaining.py
+++ b/core/test_time_remaining.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from core.models import Product, Component, BOMItem, ProductionOrder, ProductionLog
+
+
+class ProductionOrderTimeTests(TestCase):
+    def test_time_remaining_aggregates_components(self):
+        product = Product.objects.create(code="P1", name="Prod")
+        comp_a = Component.objects.create(code="C1", name="CompA", print_time_min=60)
+        comp_b = Component.objects.create(code="C2", name="CompB", print_time_min=30)
+        BOMItem.objects.create(product=product, component=comp_a, quantity=2)
+        BOMItem.objects.create(product=product, component=comp_b, quantity=1)
+        order = ProductionOrder.objects.create(product=product, quantity=1)
+        self.assertEqual(order.time_remaining_minutes(), 120)
+        self.assertEqual(order.time_remaining_hhmm, "2h00")
+        ProductionLog.objects.create(order=order, component=comp_a, quantity=1)
+        self.assertEqual(order.time_remaining_minutes(), 60)
+        self.assertEqual(order.time_remaining_hhmm, "1h00")

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -89,7 +89,10 @@
       <div class="progress" title="{{ item.progress_percent|default:0|floatformat:0 }}%">
         <span style="width: {{ item.progress_percent|default:0|floatformat:0 }}%;"></span>
       </div>
-      <div class="muted" style="text-align:right;margin-top:6px">{{ item.progress_percent|default:0|floatformat:0 }}%</div>
+      <div class="muted" style="display:flex;justify-content:space-between;margin-top:6px">
+        <span>{{ item.progress_percent|default:0|floatformat:0 }}%</span>
+        <span>Tempo restante: {{ item.time_remaining_hhmm|default:"—" }}</span>
+      </div>
       <table style="margin-top:12px">
         <thead><tr><th>Componente</th><th class="right">Qtd impressa</th><th style="width:260px">Progresso</th><th class="right">Tempo restante</th></tr></thead>
         <tbody>


### PR DESCRIPTION
## Summary
- calculate aggregated remaining time for production orders
- surface order progress and remaining time on dashboard print area
- cover order time calculations with tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68adad05a1d88320b3517cebf44d232b