### PR TITLE
Add modal to log printed quantity and deduct stock

### DIFF
--- a/core/test_log_print.py
+++ b/core/test_log_print.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+from django.urls import reverse
+from .models import Component, Product, BOMItem, ProductionOrder, ProductionLog
+
+class LogPrintAPITests(TestCase):
+    def test_log_print_deducts_inventory(self):
+        comp = Component.objects.create(code="C1", name="Comp", qty_on_hand=10, print_time_min=5)
+        prod = Product.objects.create(code="P1", name="Prod")
+        BOMItem.objects.create(product=prod, component=comp, quantity=5)
+        order = ProductionOrder.objects.create(product=prod, quantity=1)
+        url = reverse('api-log-print')
+        response = self.client.post(url, data={
+            'order_id': order.id,
+            'component_id': comp.id,
+            'quantity': 3,
+        }, content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        comp.refresh_from_db()
+        self.assertEqual(comp.qty_on_hand, 7)
+        self.assertEqual(ProductionLog.objects.filter(order=order, component=comp, quantity=3).count(), 1)

--- a/core/views.py
+++ b/core/views.py
@@ -139,6 +139,7 @@ def dashboard(request):
                     "component": comp,
                     "required": req,
                     "printed": printed,
+                    "remaining": max(0, req - printed),
                     "progress": progress,
                     "time_remaining_hhmm": minutes_to_hhmm(rem_min),
                 }
@@ -149,6 +150,7 @@ def dashboard(request):
                 total_remaining_min = rem_min
         progress_items.append(
             {
+                "order_id": op.id,
                 "product": op.product,
                 "total_required": total_required,
                 "total_printed": total_printed,

--- a/mfgsite/urls.py
+++ b/mfgsite/urls.py
@@ -42,4 +42,5 @@ urlpatterns = [
     path("api/workorders/<int:pk>/tasks/preview/", api.WorkOrderTasksPreviewAPIView.as_view(), name="api-workorder-preview"),
     path("api/products/<int:pk>/components/", api.ProductComponentsAPIView.as_view(), name="api-product-components"),
     path("api/print-time/", api.PrintTimeAPIView.as_view(), name="api-print-time"),
+    path("api/log-print/", api.LogPrintAPIView.as_view(), name="api-log-print"),
 ]

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -94,7 +94,7 @@
         <span>Tempo restante: {{ item.time_remaining_hhmm|default:"—" }}</span>
       </div>
       <table style="margin-top:12px">
-        <thead><tr><th>Componente</th><th class="right">Qtd impressa</th><th style="width:260px">Progresso</th><th class="right">Tempo restante</th></tr></thead>
+        <thead><tr><th>Componente</th><th class="right">Qtd impressa</th><th style="width:260px">Progresso</th><th class="right">Tempo restante</th><th>Ação</th></tr></thead>
         <tbody>
           {% for r in item.rows %}
           <tr>
@@ -102,6 +102,7 @@
             <td class="right">{{ r.printed|default:0|floatformat:0 }} / {{ r.required|default:0|floatformat:0 }}</td>
             <td><div class="progress"><span style="width: {{ r.progress|default:0|floatformat:0 }}%;"></span></div></td>
             <td class="right">{{ r.time_remaining_hhmm|default:"—" }}</td>
+            <td><button class="btn btn-sm log-print-btn" data-order-id="{{ item.order_id }}" data-component-id="{{ r.component.id }}" data-component-name="{{ r.component.code }} — {{ r.component.name }}" data-remaining="{{ r.remaining|default:0|floatformat:0 }}">Registrar</button></td>
           </tr>
           {% endfor %}
         </tbody>
@@ -111,6 +112,27 @@
 {% else %}
   <div id="no-printing-msg" class="block"><div class="muted">Nenhuma impressão em andamento.</div></div>
 {% endif %}
+</div>
+<div id="modal-log-print" class="modal hidden">
+  <div class="content">
+    <div class="card-title">Registrar impressão</div>
+    <div class="form">
+      {% csrf_token %}
+      <div class="field">
+        <label>Componente</label>
+        <div id="log-print-component" class="muted">—</div>
+      </div>
+      <div class="field">
+        <label>Quantidade</label>
+        <input type="number" id="log-print-qty" value="1" min="1">
+        <div id="log-print-error" class="error hidden"></div>
+      </div>
+      <div class="form-actions">
+        <button type="button" class="btn" id="log-print-cancel">Cancelar</button>
+        <button type="button" class="btn btn-primary" id="log-print-save">Adicionar</button>
+      </div>
+    </div>
+  </div>
 </div>
 <div id="modal-add-printer" class="modal hidden">
   <div class="content">
@@ -185,6 +207,30 @@ addBtn.onclick=function(){
   qtyInput.value=1;
   summaryEl.textContent='—';
   errorEl.classList.add('hidden');
+};
+
+const logModal=document.getElementById('modal-log-print');
+const logComponent=document.getElementById('log-print-component');
+const logQty=document.getElementById('log-print-qty');
+const logError=document.getElementById('log-print-error');
+const logSave=document.getElementById('log-print-save');
+const logCancel=document.getElementById('log-print-cancel');
+let logData=null;
+document.querySelectorAll('.log-print-btn').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    logData={orderId:btn.dataset.orderId,componentId:btn.dataset.componentId,remaining:parseInt(btn.dataset.remaining,10)||0};
+    logComponent.textContent=btn.dataset.componentName;
+    logQty.value=1;
+    logQty.max=logData.remaining||'';
+    logError.classList.add('hidden');
+    logModal.classList.remove('hidden');
+  });
+});
+logCancel.onclick=()=>logModal.classList.add('hidden');
+logSave.onclick=function(){
+  const qty=parseInt(logQty.value,10);
+  if(!qty||qty>logData.remaining){logError.textContent='Quantidade inválida';logError.classList.remove('hidden');return;}
+  fetch('/api/log-print/',{method:'POST',headers:{'Content-Type':'application/json','X-CSRFToken':csrfToken},body:JSON.stringify({order_id:logData.orderId,component_id:logData.componentId,quantity:qty})}).then(r=>{if(r.ok){location.reload();}else{logError.textContent='Erro ao registrar';logError.classList.remove('hidden');}}).catch(()=>{logError.textContent='Erro ao registrar';logError.classList.remove('hidden');});
 };
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow dashboard to register printed component quantities via modal
- record print logs through new API endpoint that deducts component inventory
- cover logging workflow with test

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0ca81b40832084e73d69e904f775